### PR TITLE
Use a module for status codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var ClientRequest = require('./lib/request')
 var url = require('url')
+var statusCodes = require('builtin-status-codes')
 
 var http = exports
 
@@ -32,64 +33,7 @@ http.get = function get (opts, cb) {
 http.Agent = function () {}
 http.Agent.defaultMaxSockets = 4
 
-http.STATUS_CODES = {
-	100 : 'Continue',
-	101 : 'Switching Protocols',
-	102 : 'Processing',                 // RFC 2518, obsoleted by RFC 4918
-	200 : 'OK',
-	201 : 'Created',
-	202 : 'Accepted',
-	203 : 'Non-Authoritative Information',
-	204 : 'No Content',
-	205 : 'Reset Content',
-	206 : 'Partial Content',
-	207 : 'Multi-Status',               // RFC 4918
-	300 : 'Multiple Choices',
-	301 : 'Moved Permanently',
-	302 : 'Moved Temporarily',
-	303 : 'See Other',
-	304 : 'Not Modified',
-	305 : 'Use Proxy',
-	307 : 'Temporary Redirect',
-	400 : 'Bad Request',
-	401 : 'Unauthorized',
-	402 : 'Payment Required',
-	403 : 'Forbidden',
-	404 : 'Not Found',
-	405 : 'Method Not Allowed',
-	406 : 'Not Acceptable',
-	407 : 'Proxy Authentication Required',
-	408 : 'Request Time-out',
-	409 : 'Conflict',
-	410 : 'Gone',
-	411 : 'Length Required',
-	412 : 'Precondition Failed',
-	413 : 'Request Entity Too Large',
-	414 : 'Request-URI Too Large',
-	415 : 'Unsupported Media Type',
-	416 : 'Requested Range Not Satisfiable',
-	417 : 'Expectation Failed',
-	418 : 'I\'m a teapot',              // RFC 2324
-	422 : 'Unprocessable Entity',       // RFC 4918
-	423 : 'Locked',                     // RFC 4918
-	424 : 'Failed Dependency',          // RFC 4918
-	425 : 'Unordered Collection',       // RFC 4918
-	426 : 'Upgrade Required',           // RFC 2817
-	428 : 'Precondition Required',      // RFC 6585
-	429 : 'Too Many Requests',          // RFC 6585
-	431 : 'Request Header Fields Too Large',// RFC 6585
-	500 : 'Internal Server Error',
-	501 : 'Not Implemented',
-	502 : 'Bad Gateway',
-	503 : 'Service Unavailable',
-	504 : 'Gateway Time-out',
-	505 : 'HTTP Version Not Supported',
-	506 : 'Variant Also Negotiates',    // RFC 2295
-	507 : 'Insufficient Storage',       // RFC 4918
-	509 : 'Bandwidth Limit Exceeded',
-	510 : 'Not Extended',               // RFC 2774
-	511 : 'Network Authentication Required' // RFC 6585
-}
+http.STATUS_CODES = statusCodes
 
 http.METHODS = [
 	'GET',

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "John Hiesey",
   "license": "MIT",
   "dependencies": {
+    "builtin-status-codes": "~1.0.0",
     "foreach": "^2.0.5",
     "object-keys": "^1.0.4"
   },


### PR DESCRIPTION
builtin-status-codes mirrors Node's codes exactly. In Node it depends on `http`, but for the browser it uses a built file to avoid the extra bundle weight

Aside from eliminating a bunch of lines, this allows everyone to maintained a shared set of codes. Node/io added 308 in 2014 (https://github.com/nodejs/io.js/commit/ab50fad63bcbedd7c935a9c5d2ab9e4c7202c9f2). Not like it's gonna change often, but when it does it'll be nice to have a single location for updates.